### PR TITLE
Added mapping for CMA token from settings - needed for DisplaySettings

### DIFF
--- a/source/Cute/Commands/BaseCommands/BaseLoggedInCommand.cs
+++ b/source/Cute/Commands/BaseCommands/BaseLoggedInCommand.cs
@@ -68,6 +68,7 @@ public abstract class BaseLoggedInCommand<TSettings>(IConsoleWriter console, ILo
 
         options.SpaceId = settings.SpaceId ?? options.SpaceId;
         options.Environment = settings.EnvironmentId ?? options.Environment;
+        options.ManagementApiKey = settings.ManagementToken ?? options.ManagementApiKey;
 
         _contentfulConnection = new ContentfulConnection.Builder()
             .WithHttpClient(new HttpClient())


### PR DESCRIPTION
When user is not logged in (cute login wasn't executed) then commands are failing despite providing CMA token in the options. It fails in the DisplaySettings method when trying to retrieve locales.